### PR TITLE
bugfix/handle-incorrect-reg-no

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -155,10 +155,11 @@ router.get('/registrations/:id/login', async (request, response) => {
 
   // Check that the visitor's given us a postcode.
   const {postcode} = request.query;
-  const postcodeInvalid = postcode === undefined || postcode === null;
+  const postcodeInvalid = postcode === undefined;
 
   // Check that the visitor's supplied postcode matches their stored one.
-  const postcodeIncorrect = existingReg !== undefined && existingReg.addressPostcode !== postcode;
+  const postcodeIncorrect =
+    existingReg !== undefined && existingReg !== null && existingReg.addressPostcode !== postcode;
 
   // Check that the visitor's given us a base url.
   const {redirectBaseUrl} = request.query;


### PR DESCRIPTION
Missing values from express params and queries are undefined and never null. A DB query-by-primary-key that results in 0 rows is null and never undefined.

I misunderstood that behaviour earlier. This fixes that.

Issue: None