### PR TITLE
Tell Docker where to build the image from

### DIFF
--- a/.github/workflows/dev--build-image--on-pr.yml
+++ b/.github/workflows/dev--build-image--on-pr.yml
@@ -57,7 +57,7 @@ jobs:
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
       run: |
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:prerelease
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:prerelease .
 
     - name: Push the Docker Image to Amazon ECR
       env:


### PR DESCRIPTION
We were missing the 'location' parameter of the docker build command.