### PR TITLE
Feature/drop recreate registration view

### DIFF
--- a/util/db/migrations/20210924113712-drop-recreate-registration-view.js
+++ b/util/db/migrations/20210924113712-drop-recreate-registration-view.js
@@ -1,0 +1,33 @@
+'use strict';
+if (process.env.NODE_ENV === 'production') {
+  module.exports = {
+    up: async (queryInterface, Sequelize) => {
+      await queryInterface.sequelize.query('DROP VIEW traps_Registrations;', {
+        type: Sequelize.QueryTypes.RAW
+      });
+
+      await queryInterface.sequelize.query('CREATE VIEW traps_Registrations AS SELECT * FROM traps."Registrations";', {
+        type: Sequelize.QueryTypes.RAW
+      });
+    },
+
+    down: async (queryInterface, Sequelize) => {
+      await queryInterface.sequelize.query('DROP VIEW traps_Registrations;', {
+        type: Sequelize.QueryTypes.RAW
+      });
+
+      await queryInterface.sequelize.query('CREATE VIEW traps_Registrations AS SELECT * FROM traps."Registrations";', {
+        type: Sequelize.QueryTypes.RAW
+      });
+    }
+  };
+} else {
+  module.exports = {
+    up: () => {
+      return Promise.resolve();
+    },
+    down: () => {
+      return Promise.resolve();
+    }
+  };
+}


### PR DESCRIPTION
Part of issue https://github.com/Scottish-Natural-Heritage/Licensing/issues/903.

PostgreSQL doesn't use `SELECT *` when it saves the code to create a view, but rather keeps all the column names, so the view needs to be dropped and recreated so Superset can sync with the updated view and see the new `expiryDate` column.