### PR TITLE
feature/test-trigger-scheduled-tasks

### DIFF
--- a/src/scheduled-tasks.js
+++ b/src/scheduled-tasks.js
@@ -21,7 +21,7 @@ const initScheduledJobs = () => {
 
     // Tasks here.
 
-    if (currentDate.getDate() === 1) {
+    if (currentDate.getDate() === 17) {
       const promises = [];
 
       // Check for expired licences of meat bait users that did not submit a return, on the 1st of every month.
@@ -40,14 +40,14 @@ const initScheduledJobs = () => {
       }
 
       // Check for valid licences of meat bait users that did not submit a return, on the 1st of April.
-      if (currentDate.getMonth() === 3) {
+      if (currentDate.getMonth() === 1) {
         promises.push(
           axios.post(`http://localhost:${config.port}${config.pathPrefix}/v2/valid-licence-no-returns-reminder`)
         );
       }
 
       // Check for valid licences of meat bait users, on the 1st of December.
-      if (currentDate.getMonth() === 11) {
+      if (currentDate.getMonth() === 1) {
         promises.push(
           axios.post(`http://localhost:${config.port}${config.pathPrefix}/v2/valid-licence-returns-due-reminder`)
         );


### PR DESCRIPTION
Modifies the date the `node-cron` tasks trigger on to 17th February so they can be tested.

Issues:
https://github.com/Scottish-Natural-Heritage/Licensing/issues/1484
https://github.com/Scottish-Natural-Heritage/Licensing/issues/1485
https://github.com/Scottish-Natural-Heritage/Licensing/issues/1486
https://github.com/Scottish-Natural-Heritage/Licensing/issues/1487