### PR TITLE
bugfix/allow-zero-larsens

### DIFF
--- a/src/v2-router.js
+++ b/src/v2-router.js
@@ -209,8 +209,8 @@ const cleanPatchReturnInput = (id, body) => ({
 
   // Copy across the year the return is for and the number of larsen mate / pod traps in which meat baits were used.
   year: body.year ? body.year : undefined,
-  numberLarsenMate: body.numberLarsenMate ? body.numberLarsenMate : undefined,
-  numberLarsenPod: body.numberLarsenPod ? body.numberLarsenPod : undefined
+  numberLarsenMate: Number.isNaN(body.numberLarsenMate) ? undefined : body.numberLarsenMate,
+  numberLarsenPod: Number.isNaN(body.numberLarsenPod) ? undefined : body.numberLarsenPod
 });
 
 /**


### PR DESCRIPTION
Adds code to allow `0` as a possible value for the number of larsen mate / pod traps used if meat baits were deployed. Issue https://github.com/Scottish-Natural-Heritage/Licensing/issues/2018.