### PR TITLE
bugfix/add-missing-secrets-decrypt

### DIFF
--- a/.github/workflows/dev--build-image--on-pr.yml
+++ b/.github/workflows/dev--build-image--on-pr.yml
@@ -19,6 +19,13 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Decrypt the secrets
+        env:
+          JWT_KEY_GPG_PASSPHRASE: ${{ secrets.TR_JWT_KEY_GPG_PASSPHRASE }}
+        run: |
+          chmod +x ./decrypt_secrets.sh
+          ./decrypt_secrets.sh
+
       - name: Install all the pre-requisites
         run: |
           npm ci


### PR DESCRIPTION
In order to test on DEV we need the JWT key. This code decrypts it as part of the GA workflow script that is triggered on PRs to `develop` and `main`. Required to test part of issue https://github.com/Scottish-Natural-Heritage/Deer-Online-Services/issues/971.