### PR TITLE
bugfix/2069-renew-list

### DIFF
--- a/src/controllers/v2/registration.js
+++ b/src/controllers/v2/registration.js
@@ -102,18 +102,16 @@ const RegistrationController = {
         {
           model: Note
         },
-        {model: Revocation, paranoid: false},
+        {model: Revocation},
         {
           model: Return,
           include: [
             {
               model: NonTargetSpecies
             }
-          ],
-          paranoid: false
+          ]
         }
-      ],
-      paranoid: false
+      ]
     }),
 
   /**


### PR DESCRIPTION
Remove paranoid from findAllByEmail to prevent soft deleted records displaying in the renew-list table